### PR TITLE
add local.langchao.org:3000 to allowed CORS

### DIFF
--- a/config/security.ts
+++ b/config/security.ts
@@ -9,7 +9,7 @@ export default {
   *                                                                          *
   ***************************************************************************/
 
-    origin: (process.env.CORS || 'http://localhost:3000,https://langchao.org,https://v2land.net').split(','),
+    origin: (process.env.CORS || 'http://localhost:3000,http://local.langchao.org:3000,https://langchao.org,https://v2land.net').split(','),
 
     /** *************************************************************************
   *                                                                          *


### PR DESCRIPTION
We use `local.langchao.org` to debug locally (with `3000` as the default non-privileged port). But the BE rejects requests since the CORS is not in the allowlist. This PR adds it to the list.